### PR TITLE
ホーム画面のレイアウトファイルにあるハードコードを置き換える

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -25,7 +25,7 @@
         android:id="@+id/home_Message"
         android:layout_width="350dp"
         android:layout_height="wrap_content"
-        android:text="右下の検索ボタンから検索条件を設定し、検索してください。"
+        android:text="@string/home_guide_search"
         android:textSize="24sp"
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="guide_search">右下の検索ボタンから検索してください。</string>
     <string name="searching">検索中です</string>
     <string name="please_select_distance">距離を選択してください</string>
+    <string name="home_guide_search">右下の検索ボタンから検索条件を設定し、検索してください。</string>
 </resources>


### PR DESCRIPTION
・目的
ホーム画面のレイアウトファイルにあるハードコードを置き換える
・達成条件
string.xmlに定義し、ハードコードで書かれている部分と置き換える
・実装の概要
string.xmlにハードコードで書かれた文言を登録し、レイアウトファイル内で呼び出す

string.xml
`<string name="home_guide_search">右下の検索ボタンから検索条件を設定し、検索してください。</string>`

fragment_home.xml
 `android:text="@string/home_guide_search"`
