### PR TITLE
ランダム表示画面のフォントサイズをspからdpに変更

### DIFF
--- a/app/src/main/res/layout/fragment_shuffle.xml
+++ b/app/src/main/res/layout/fragment_shuffle.xml
@@ -39,7 +39,7 @@
                 android:paddingBottom="8dp"
                 android:text="@string/shop_name_label"
                 android:textColor="@color/black"
-                android:textSize="20sp"
+                android:textSize="20dp"
                 android:textStyle="bold"
                 android:visibility="invisible" />
 
@@ -49,7 +49,7 @@
                 android:layout_height="wrap_content"
                 android:text=""
                 android:textColor="@android:color/black"
-                android:textSize="18sp"
+                android:textSize="18dp"
                 android:textStyle="bold"
                 android:layout_gravity="center"/>
 
@@ -62,7 +62,7 @@
                 android:paddingBottom="8dp"
                 android:text="@string/shop_address_label"
                 android:textColor="@color/black"
-                android:textSize="20sp"
+                android:textSize="20dp"
                 android:textStyle="bold"
                 android:visibility="invisible" />
 
@@ -72,7 +72,7 @@
                 android:layout_height="wrap_content"
                 android:text=""
                 android:textColor="@android:color/black"
-                android:textSize="18sp"
+                android:textSize="18dp"
                 android:textStyle="bold"
                 android:layout_gravity="center"/>
 


### PR DESCRIPTION
・対処内容
ランダム表示画面のフォントサイズをspからdpに変更

・具体的な対処内容
sp→dpに変更
fragment_shuffle.xml
42行目
`android:textSize="20dp"`
52行目
`android:textSize="18dp"`
65行目
`android:textSize="20dp"`
75行目
`android:textSize="18dp"`


・確認内容
文字サイズ変更に伴い、表記に問題がないこと