### PR TITLE
ボトムシートのフォントサイズをspからdpに変更

### DIFF
--- a/app/src/main/res/layout/fragment_search_bottom_sheet_dialog.xml
+++ b/app/src/main/res/layout/fragment_search_bottom_sheet_dialog.xml
@@ -17,7 +17,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/search"
-        android:textSize="24sp"
+        android:textSize="24dp"
         android:textStyle="bold"
         app:layout_constraintStart_toStartOf="@+id/distance_title"
         app:layout_constraintTop_toTopOf="parent" />
@@ -27,7 +27,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/distance"
-        android:textSize="18sp"
+        android:textSize="18dp"
         android:textStyle="bold"
         app:layout_constraintStart_toStartOf="@+id/title"
         app:layout_constraintTop_toBottomOf="@+id/title" />


### PR DESCRIPTION
・対処内容
ボトムシートのフォントサイズをspからdpに変更

・具体的な対処内容
sp→dpに変更
fragment_search_bottom_sheet_dialog.xml
20行目
`android:textSize="24dp"`
30行目
`android:textSize="18dp"`


・確認内容
文字サイズ変更に伴い、表記に問題がないこと