### PR TITLE
ホーム画面のフォントサイズをspからdpに変更

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -26,7 +26,7 @@
         android:layout_width="350dp"
         android:layout_height="wrap_content"
         android:text="@string/home_guide_search"
-        android:textSize="24sp"
+        android:textSize="24dp"
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
・対処内容
ホーム画面のフォントサイズをspからdpに変更

・具体的な対処内容
sp→dpに変更
res/layout/fragment_home.xml
29行目
`android:textSize="20dp"`

・確認内容
文字サイズ変更に伴い、表記に問題がないこと