### PR TITLE
店の詳細画面のフォントサイズをspからdpに変更

### DIFF
--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -30,7 +30,7 @@
             android:paddingBottom="8dp"
             android:text="@string/name_label"
             android:textColor="@color/black"
-            android:textSize="20sp"
+            android:textSize="20dp"
             android:textStyle="bold"
             android:layout_marginStart="50dp"/>
 
@@ -40,7 +40,7 @@
             android:layout_height="wrap_content"
             android:text="京都北白川ラーメン魁力屋 イオンモールりんくう泉南店"
             android:textColor="@color/black"
-            android:textSize="18sp"
+            android:textSize="18dp"
             android:textStyle="bold"
             android:layout_gravity="center"/>
 
@@ -52,7 +52,7 @@
             android:paddingBottom="8dp"
             android:text="@string/address_label"
             android:textColor="@color/black"
-            android:textSize="20sp"
+            android:textSize="20dp"
             android:textStyle="bold"
             android:layout_marginStart="50dp"/>
 
@@ -62,7 +62,7 @@
             android:layout_height="wrap_content"
             android:text="大阪府泉南市りんくう南浜３−１２ 1F レストラン街内"
             android:textColor="@color/black"
-            android:textSize="18sp"
+            android:textSize="18dp"
             android:textStyle="bold"
             android:layout_gravity="center"/>
 
@@ -72,7 +72,7 @@
             android:layout_height="wrap_content"
             android:text="@string/hours_label"
             android:textColor="@color/black"
-            android:textSize="20sp"
+            android:textSize="20dp"
             android:textStyle="bold"
             android:layout_marginTop="8dp"
             android:paddingBottom="8dp"
@@ -84,7 +84,7 @@
             android:layout_height="wrap_content"
             android:text="月～日、祝日、祝前日: 11:00～23:00 （料理L.O. 23:00）"
             android:textColor="@color/black"
-            android:textSize="18sp"
+            android:textSize="18dp"
             android:textStyle="bold"
             android:layout_gravity="center" />
 


### PR DESCRIPTION
・対処内容
店の詳細画面のフォントサイズをspからdpに変更

・具体的な対処内容
sp→dpに変更
res/layout/fragment_detail.xml
33行目
`android:textSize="20dp"`
43行目
`android:textSize="18dp"`
55行目
`android:textSize="20dp"`
65行目
`android:textSize="18dp"`
75行目
`android:textSize="20dp"`
87行目
`android:textSize="18dp"`

・確認内容
文字サイズ変更に伴い、表記に問題がないこと