### PR TITLE
ボトムシートのメートルの表記が大文字になっているのを小文字に変更

### DIFF
--- a/app/src/main/res/layout/fragment_search_bottom_sheet_dialog.xml
+++ b/app/src/main/res/layout/fragment_search_bottom_sheet_dialog.xml
@@ -46,21 +46,24 @@
             style="?attr/materialButtonOutlinedStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/five_hundred_meters" />
+            android:text="@string/five_hundred_meters"
+            android:textAllCaps="false" />
 
         <Button
             android:id="@+id/button2"
             style="?attr/materialButtonOutlinedStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/one_thousand_meters" />
+            android:text="@string/one_thousand_meters"
+            android:textAllCaps="false" />
 
         <Button
             android:id="@+id/button3"
             style="?attr/materialButtonOutlinedStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/two_thousand_meters" />
+            android:text="@string/two_thousand_meters"
+            android:textAllCaps="false" />
     </com.google.android.material.button.MaterialButtonToggleGroup>
 
     <Button


### PR DESCRIPTION
・対処内容
ボトムシートのメートルの表記を大文字から小文字に変更

・具体的な対処内容
M→mに変更
res/layout/fragment_search_bottom_sheet_dialog.xml
50、58，66行目に以下のコード追加
android:textAllCaps="false"

・確認内容
ボトムシートの表記が変更されていること