### PR TITLE
Feature/rename bottom sheet button

### DIFF
--- a/app/src/main/java/jp/example/tanmen/view/Fragment/SearchBottomSheetDialogFragment.kt
+++ b/app/src/main/java/jp/example/tanmen/view/Fragment/SearchBottomSheetDialogFragment.kt
@@ -69,16 +69,16 @@ class SearchBottomSheetDialogFragment : BottomSheetDialogFragment() {
 
     private fun getCheckedButton(btnId: Int): ShopService.UrlCreate.Distance? {
         when (btnId) {
-            R.id.button1 -> {
+            R.id.five_hundred_button -> {
                 //500m
                 return ShopService.UrlCreate.Distance.fiveHundred
             }
-            R.id.button2 -> {
+            R.id.one_thousand_button -> {
                 //1000m
                 return ShopService.UrlCreate.Distance.oneThousand
 
             }
-            R.id.button3 -> {
+            R.id.two_thousand_button -> {
                 //2000m
                 return ShopService.UrlCreate.Distance.twoThousand
             }

--- a/app/src/main/res/layout/fragment_search_bottom_sheet_dialog.xml
+++ b/app/src/main/res/layout/fragment_search_bottom_sheet_dialog.xml
@@ -42,7 +42,7 @@
         app:selectionRequired="true">
 
         <Button
-            android:id="@+id/button1"
+            android:id="@+id/five_hundred_button"
             style="?attr/materialButtonOutlinedStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -50,7 +50,7 @@
             android:textAllCaps="false" />
 
         <Button
-            android:id="@+id/button2"
+            android:id="@+id/one_thousand_button"
             style="?attr/materialButtonOutlinedStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -58,7 +58,7 @@
             android:textAllCaps="false" />
 
         <Button
-            android:id="@+id/button3"
+            android:id="@+id/two_thousand_button"
             style="?attr/materialButtonOutlinedStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
・対処内容
ボトムシートの距離を選択するボタンのidを変更

・具体的な対処内容
各ボタンのidを変更
res/layout/fragment_search_bottom_sheet_dialog
45行目
`android:id="@+id/five_hundred_button"`
53行目
`android:id="@+id/one_thousand_button"`
61行目
`android:id="@+id/two_thousand_button"`

view/fragment/SearchBottomSheetDialogFragment.kt
idを指定している部分を変更
72行目から
```
R.id.five_hundred_button -> {
    //500m
    return ShopService.UrlCreate.Distance.fiveHundred
}
R.id.one_thousand_button -> {
    //1000m
    return ShopService.UrlCreate.Distance.oneThousand

}
R.id.two_thousand_button -> {
    //2000m
    return ShopService.UrlCreate.Distance.twoThousand
}
```

・確認内容
ボタンのid変更に伴い、表記、ボタン選択動作に問題がないこと