### PR TITLE
各画面にある定義されているvarからvalに変更

### DIFF
--- a/app/src/main/java/jp/example/tanmen/Adapter/ShopListAdapter.kt
+++ b/app/src/main/java/jp/example/tanmen/Adapter/ShopListAdapter.kt
@@ -19,8 +19,8 @@ class ShopListAdapter(var shopList: MutableList<Shop>)
     }
 
     class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        var image: ImageView = itemView.findViewById(R.id.image)
-        var shopAddress: TextView = itemView.findViewById(R.id.detail_name)
+        val image: ImageView = itemView.findViewById(R.id.image)
+        val shopAddress: TextView = itemView.findViewById(R.id.detail_name)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) : ViewHolder {

--- a/app/src/main/java/jp/example/tanmen/Model/Entity/Shop.kt
+++ b/app/src/main/java/jp/example/tanmen/Model/Entity/Shop.kt
@@ -3,8 +3,8 @@ package jp.example.tanmen.Model.Entity
 import java.io.Serializable
 
 data class Shop(
-    var image: String,
-    var name: String,
-    var address: String?,
-    var hours: String?
+    val image: String,
+    val name: String,
+    val address: String?,
+    val hours: String?
 ): Serializable

--- a/app/src/main/java/jp/example/tanmen/view/Activity/MainActivity.kt
+++ b/app/src/main/java/jp/example/tanmen/view/Activity/MainActivity.kt
@@ -26,7 +26,7 @@ import timber.log.Timber
 
 class MainActivity : AppCompatActivity(), LocationListener {
     private lateinit var binding: ActivityMainBinding
-    private var requestPermissionLauncher = registerForActivityResult(
+    private val requestPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { isGranted: Boolean ->
         if (isGranted) {

--- a/app/src/main/java/jp/example/tanmen/view/Fragment/HomeFragment.kt
+++ b/app/src/main/java/jp/example/tanmen/view/Fragment/HomeFragment.kt
@@ -23,7 +23,7 @@ import timber.log.Timber
 class HomeFragment : Fragment() {
     private lateinit var binding: FragmentHomeBinding
     private var adapter: ShopListAdapter? = null
-    private var shopList = mutableListOf<Shop>()
+    private val shopList = mutableListOf<Shop>()
     private val viewModel: HomeViewModel by viewModels()
 
     override fun onCreateView(

--- a/app/src/main/java/jp/example/tanmen/viewModel/ShuffleViewModel.kt
+++ b/app/src/main/java/jp/example/tanmen/viewModel/ShuffleViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class ShuffleViewModel : ViewModel() {
-    var data = MutableLiveData<Shop>()
+    val data = MutableLiveData<Shop>()
 
     fun getData() {
         ShopService.instance.fetchUrl(ShopService.UrlCreate.Distance.fiveHundred) {


### PR DESCRIPTION
・対処内容
各画面にvarで定義されている変数をvalに変更

・具体的な対処内容
var→valに変更
Adapter/ShopListAdapter.kt　22、23行目
```
var image: ImageView = itemView.findViewById(R.id.image)
var shopAddress: TextView = itemView.findViewById(R.id.detail_name)
```
　　　↓
```
val image: ImageView = itemView.findViewById(R.id.image)
val shopAddress: TextView = itemView.findViewById(R.id.detail_name)
```

Model/Entity/Shop.kt　6~9行目
```
var image: String,
var name: String,
var address: String?,
var hours: String?
```
　　　↓
```
val image: String,
val name: String,
val address: String?,
val hours: String?
```

view/MainActivity.kt　29行目
`private var requestPermissionLauncher = registerForActivityResult(`
　　　↓
`private val requestPermissionLauncher = registerForActivityResult(`

view/Fragment/HomeFragment.kt　26行目
`private var shopList = mutableListOf<Shop>()`
　　　↓
`private val shopList = mutableListOf<Shop>()`

viewModel/ShuffleViewModel.kt　13行目
`var data = MutableLiveData<Shop>()`
　　　↓
`val data = MutableLiveData<Shop>()`

・確認内容
変数の定義をvarからvalに変更したことで、動作に問題がないこと