### PR TITLE
各画面のコードにスコープ関数を適応させる

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,11 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\PC_User\.android\avd\Pixel_4_API_28.avd" />
+            <value value="C:\Users\PC_User\.android\avd\Pixel_4_API_32.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-03-21T14:45:32.432822400Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-04-04T10:08:01.230684600Z" />
   </component>
 </project>

--- a/app/src/main/java/jp/example/tanmen/Adapter/ShopListAdapter.kt
+++ b/app/src/main/java/jp/example/tanmen/Adapter/ShopListAdapter.kt
@@ -32,9 +32,11 @@ class ShopListAdapter(var shopList: MutableList<Shop>)
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val shop = shopList[position]
         Picasso.get().load(shop.image).resize(72, 72).into(holder.image)
-        holder.shopAddress.text = shop.name
-        holder.itemView.setOnClickListener {
-            listener.onItemClick(shop)
+        holder.apply {
+            shopAddress.text = shop.name
+            itemView.setOnClickListener {
+                listener.onItemClick(shop)
+            }
         }
     }
 

--- a/app/src/main/java/jp/example/tanmen/view/Fragment/DetailFragment.kt
+++ b/app/src/main/java/jp/example/tanmen/view/Fragment/DetailFragment.kt
@@ -23,10 +23,12 @@ class DetailFragment : Fragment() {
 
         val args = arguments?.getSerializable("shopDetail") as Shop
         if (args != null) {
-            Picasso.get().load(args.image).resize(300, 300).into(binding.shopPhoto)
-            binding.shopName.text = args.name
-            binding.shopAddress.text = args.address
-            binding.shopBusinessHours.text = args.hours
+            binding.apply {
+                Picasso.get().load(args.image).resize(300, 300).into(shopPhoto)
+                shopName.text = args.name
+                shopAddress.text = args.address
+                shopBusinessHours.text = args.hours
+            }
         }
         Timber.d("$args")
 

--- a/app/src/main/java/jp/example/tanmen/view/Fragment/HomeFragment.kt
+++ b/app/src/main/java/jp/example/tanmen/view/Fragment/HomeFragment.kt
@@ -61,8 +61,10 @@ class HomeFragment : Fragment() {
     @SuppressLint("NotifyDataSetChanged")
     fun changeShopList(shopLists: MutableList<Shop>) {
         GlobalScope.launch(Dispatchers.Main) {
-            binding.homeMessage.visibility = View.GONE
-            binding.homeImage.visibility = View.GONE
+            binding.apply {
+                homeMessage.visibility = View.GONE
+                homeImage.visibility = View.GONE
+            }
             adapter?.shopList = shopLists
             adapter?.notifyDataSetChanged()
         }

--- a/app/src/main/java/jp/example/tanmen/view/Fragment/MainFragment.kt
+++ b/app/src/main/java/jp/example/tanmen/view/Fragment/MainFragment.kt
@@ -24,17 +24,19 @@ class MainFragment : Fragment() {
     ): View {
         binding = FragmentMainBinding.inflate(inflater, container, false)
 
-        binding.viewPager.adapter = BottomNavigationPagerAdapter(this)
-        binding.viewPager.isUserInputEnabled = false
+        binding.let {
+            it.viewPager.adapter = BottomNavigationPagerAdapter(this)
+            it.viewPager.isUserInputEnabled = false
 
-        binding.bottomNavigation.setOnItemSelectedListener {
-            val currentItem = getCurrentItem(it.itemId)
-            binding.viewPager.setCurrentItem(currentItem, true)
-            return@setOnItemSelectedListener true
-        }
+            it.bottomNavigation.setOnItemSelectedListener {
+                val currentItem = getCurrentItem(it.itemId)
+                binding.viewPager.setCurrentItem(currentItem, true)
+                return@setOnItemSelectedListener true
+            }
 
-        binding.fab.setOnClickListener {
-            openBottomSheet()
+            it.fab.setOnClickListener {
+                openBottomSheet()
+            }
         }
 
         childFragmentManager.setFragmentResultListener(

--- a/app/src/main/java/jp/example/tanmen/view/Fragment/SearchBottomSheetDialogFragment.kt
+++ b/app/src/main/java/jp/example/tanmen/view/Fragment/SearchBottomSheetDialogFragment.kt
@@ -37,33 +37,35 @@ class SearchBottomSheetDialogFragment : BottomSheetDialogFragment() {
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentSearchBottomSheetDialogBinding.inflate(inflater, container, false)
+        binding.apply {
+            searchButton.setOnClickListener {
+                lifecycleScope.launch {
+                    if (ShopService.instance.location != null) {
+                        val btnId = binding.toggleButton.checkedButtonId
+                        if (btnId != -1) {
+                            val distance = getCheckedButton(btnId)
+                            ShopService.instance.fetchUrl(distance) {
+                                Timber.d("$it")
 
-        binding.searchButton.setOnClickListener {
-            lifecycleScope.launch {
-                if (ShopService.instance.location != null) {
-                    val btnId = binding.toggleButton.checkedButtonId
-                    if (btnId != -1) {
-                        val distance = getCheckedButton(btnId)
-                        ShopService.instance.fetchUrl(distance) {
-                            Timber.d("$it")
+                                val bundle = bundleOf(KEY_CLICK to it)
+                                setFragmentResult(_requestKey, bundle)
 
-                            val bundle = bundleOf(KEY_CLICK to it)
-                            setFragmentResult(_requestKey, bundle)
-
+                            }
+                        }else {
+                            Toast.makeText(activity, getString(R.string.please_select_distance), Toast.LENGTH_SHORT).show()
+                            Timber.d("距離が選択されていません")
                         }
-                    }else {
-                        Toast.makeText(activity, getString(R.string.please_select_distance), Toast.LENGTH_SHORT).show()
-                        Timber.d("距離が選択されていません")
+                    } else {
+                        Timber.d("locationがnullです")
                     }
-                } else {
-                    Timber.d("locationがnullです")
                 }
+            }
+
+            cancelButton.setOnClickListener {
+                dismiss()
             }
         }
 
-        binding.cancelButton.setOnClickListener {
-            dismiss()
-        }
         return binding.root
     }
 

--- a/app/src/main/java/jp/example/tanmen/view/Fragment/ShuffleFragment.kt
+++ b/app/src/main/java/jp/example/tanmen/view/Fragment/ShuffleFragment.kt
@@ -31,8 +31,10 @@ class ShuffleFragment : Fragment() {
     ): View {
         binding = FragmentShuffleBinding.inflate(inflater, container, false)
 
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.shuffleViewModel = viewModel
+        binding.apply {
+            lifecycleOwner = viewLifecycleOwner
+            shuffleViewModel = viewModel
+        }
 
         return binding.root
     }
@@ -55,8 +57,10 @@ class ShuffleFragment : Fragment() {
                         d("オブザーブ内null")
                         GlobalScope.launch(Dispatchers.Main) {
                             progressDialog.dismiss()
-                            binding.nameLabel.visibility = View.GONE
-                            binding.addressLabel.visibility = View.GONE
+                            binding.apply {
+                                nameLabel.visibility = View.GONE
+                                addressLabel.visibility = View.GONE
+                            }
                             AlertDialog.Builder(requireActivity())
                                 .setMessage(getString(R.string.no_search_result))
                                 .setPositiveButton(getString(R.string.yes), object : DialogInterface.OnClickListener {
@@ -72,12 +76,14 @@ class ShuffleFragment : Fragment() {
                         }
                     } else {
                         GlobalScope.launch(Dispatchers.Main) {
-                            binding.nameLabel.visibility = View.VISIBLE
-                            binding.addressLabel.visibility = View.VISIBLE
+                            binding.apply {
+                                nameLabel.visibility = View.VISIBLE
+                                addressLabel.visibility = View.VISIBLE
+                                Picasso.get().load(it.image).resize(72, 72).into(shopPhoto)
+                                shopName.text = it.name
+                                shopAddress.text = it.address
+                            }
                             progressDialog.dismiss()
-                            Picasso.get().load(it.image).resize(72, 72).into(binding.shopPhoto)
-                            binding.shopName.text = it.name
-                            binding.shopAddress.text = it.address
                         }
                     }
                 }


### PR DESCRIPTION
・対処内容
各画面にスコープ関数を適応させる

・具体的な対処内容
Adapter\ShopListAdapter.kt　35～39行目
`holder.apply {
shopAddress.text = shop.name
itemView.setOnClickListener {
    listener.onItemClick(shop)
}`

view\Fragment\DetailFragment.kt　26～31行目
`            binding.apply {
                Picasso.get().load(args.image).resize(300, 300).into(shopPhoto)
                shopName.text = args.name
                shopAddress.text = args.address
                shopBusinessHours.text = args.hours
            }`

view\Fragment\HomeFragment.kt　64～67行目
`            binding.apply {
                homeMessage.visibility = View.GONE
                homeImage.visibility = View.GONE
            }`

view\Fragment\MainFragment.kt　27～39行目
`        binding.let {
            it.viewPager.adapter = BottomNavigationPagerAdapter(this)
            it.viewPager.isUserInputEnabled = false
            it.bottomNavigation.setOnItemSelectedListener {
                val currentItem = getCurrentItem(it.itemId)
                binding.viewPager.setCurrentItem(currentItem, true)
                return@setOnItemSelectedListener true
            }
            it.fab.setOnClickListener {
                openBottomSheet()
            }`

・確認内容
動作に問題がないこと