### PR TITLE
詳細画面の下部に余白を追加する

### DIFF
--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -11,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:paddingBottom="24dp">
+        android:paddingBottom="100dp">
 
         <ImageView
             android:id="@+id/shop_photo"


### PR DESCRIPTION
・対処内容
詳細画面の下部に余白を追加する

・具体的な対処内容
詳細画面の下部に余白を追加する
res\layout\fragment_detail.xml
13行目
`android:paddingBottom="100dp"`

・確認内容
詳細画面の下部に余白を追加したことで、表記、動作に問題がないことを確認