### PR TITLE
ランダム表示画面へ２回目以降の遷移の際にデータを取得するように修正

### DIFF
--- a/app/src/main/java/jp/example/tanmen/view/Fragment/ShuffleFragment.kt
+++ b/app/src/main/java/jp/example/tanmen/view/Fragment/ShuffleFragment.kt
@@ -33,6 +33,7 @@ class ShuffleFragment : Fragment() {
     private val viewModel: ShuffleViewModel by viewModels()
     var progressDialog: ProgressDialog? = null
     private val shopService = ShopService.instance
+    private var isFirst = true
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -54,15 +55,20 @@ class ShuffleFragment : Fragment() {
     
     override fun onResume() {
         super.onResume()
+        locationAuthority()
     }
 
     private fun locationAuthority() {
         if (checkSinglePermission(Manifest.permission.ACCESS_COARSE_LOCATION) &&
             checkSinglePermission(Manifest.permission.ACCESS_FINE_LOCATION)) {
-            progressDialog?.apply {
-                setTitle(getString(R.string.loading))
-                setProgressStyle(ProgressDialog.STYLE_SPINNER)
-                show()
+            if (shopService.location.value != null && !isFirst) {
+                viewModel.getData()
+            } else {
+                progressDialog?.apply {
+                    setTitle(getString(R.string.loading))
+                    setProgressStyle(ProgressDialog.STYLE_SPINNER)
+                    show()
+                }
             }
         } else {
             val builder = AlertDialog.Builder(requireActivity())
@@ -77,6 +83,7 @@ class ShuffleFragment : Fragment() {
             builder.create()
             builder.show()
         }
+        isFirst = false
     }
 
     private fun checkSinglePermission(permission: String): Boolean =


### PR DESCRIPTION
・対処内容
ランダム表示画面の2回目以降の遷移時にデータ取得し、表示させるように修正

・具体的な対処内容
view\Fragment\ShuffleFragment.kt
36行目
`private var isFirst = true`

58行目
`locationAuthority()`

64～72行目
```
if (shopService.location.value != null && !isFirst) {
    viewModel.getData()
} else {
    progressDialog?.apply {
        setTitle(getString(R.string.loading))
        setProgressStyle(ProgressDialog.STYLE_SPINNER)
        show()
    }
}
```
86行目
`isFirst = false`

・確認内容
ランダム表示画面へ遷移時にデータが取得され、表記に問題がないこと