### PR TITLE
ランダム表示画面の位置情報取得する際に出るアラートを３秒表示、自動で閉じるように修正

### DIFF
--- a/app/src/main/java/jp/example/tanmen/view/Fragment/ShuffleFragment.kt
+++ b/app/src/main/java/jp/example/tanmen/view/Fragment/ShuffleFragment.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.os.Handler
 import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
@@ -64,11 +65,18 @@ class ShuffleFragment : Fragment() {
             if (shopService.location.value != null && !isFirst) {
                 viewModel.getData()
             } else {
+                val handler = Handler()
+                val run = Runnable {
+                    kotlin.run {
+                        progressDialog?.dismiss()
+                    }
+                }
                 progressDialog?.apply {
                     setTitle(getString(R.string.loading))
                     setProgressStyle(ProgressDialog.STYLE_SPINNER)
                     show()
                 }
+                handler.postDelayed(run, 3000)
             }
         } else {
             val builder = AlertDialog.Builder(requireActivity())


### PR DESCRIPTION
・対処内容
ランダム表示画面の位置情報取得する際に出るアラートを３秒表示、自動で閉じるように修正

・具体的な対処内容
view\Fragment\ShuffleFragment.kt
68～73行目
```
val handler = Handler()
val run = Runnable {
    kotlin.run {
        progressDialog?.dismiss()
    }
}
```
79行目
`handler.postDelayed(run, 3000)`

・確認内容
設定画面からアプリに戻った際に自動でアラートが閉じることに問題がないこと