### PR TITLE
Feature/replace viewmodel in bottom sheet

### DIFF
--- a/app/src/main/java/jp/example/tanmen/viewModel/SearchBottomSheetDialogViewModel.kt
+++ b/app/src/main/java/jp/example/tanmen/viewModel/SearchBottomSheetDialogViewModel.kt
@@ -1,0 +1,16 @@
+package jp.example.tanmen.viewModel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import jp.example.tanmen.Model.API.ShopService
+import jp.example.tanmen.Model.Entity.Shop
+
+class SearchBottomSheetDialogViewModel : ViewModel() {
+    var shopListLiveData: MutableLiveData<MutableList<Shop>> = MutableLiveData()
+
+    fun getShopList(distance: ShopService.UrlCreate.Distance) {
+        ShopService.instance.fetchUrl(distance) {
+            shopListLiveData.postValue(it)
+        }
+    }
+}

--- a/app/src/main/java/jp/example/tanmen/viewModel/SearchBottomSheetDialogViewModel.kt
+++ b/app/src/main/java/jp/example/tanmen/viewModel/SearchBottomSheetDialogViewModel.kt
@@ -10,7 +10,11 @@ class SearchBottomSheetDialogViewModel : ViewModel() {
 
     fun getShopList(distance: ShopService.UrlCreate.Distance) {
         ShopService.instance.fetchUrl(distance) {
-            shopListLiveData.postValue(it)
+            if (it.isEmpty()) {
+                shopListLiveData.postValue(null)
+            } else {
+                shopListLiveData.postValue(it)
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="shop_name_label">店名</string>
     <string name="shop_address_label">住所</string>
     <string name="loading">位置情報取得中です...</string>
+    <string name="loading_return">位置情報取得中です...\n再度お試しください。</string>
     <string name="location_false">位置情報を取得できませんでした。\n位置情報をONにして、再度お試しください。</string>
     <string name="alert_dialog">アプリを継続するためには位置情報の取得が必要です。設定後、再起動を行ってご利用ください。</string>
     <string name="alert_message">画面に権限がないので表示できません。</string>


### PR DESCRIPTION
・対処内容
ボトムシートから検索時に位置情報がない場合は文言を表示するように変更

・具体的な対処内容
SearchBottomSheetDialogFragment.kt 
51行目
```
searchButton.setOnClickListener {
     searchStart()
}
```

67行目
```
    private fun searchStart() {
        if (ShopService.instance.location.value != null) {
            lifecycleScope.launch {
                val btnId = binding.toggleButton.checkedButtonId
                if (btnId != -1) {
                    val distance = getCheckedButton(btnId)
                    if (distance != null) {
                        viewModel.getShopList(distance)
                    }
                }else {
                    Toast.makeText(activity, getString(R.string.please_select_distance), Toast.LENGTH_SHORT).show()
                    Timber.d("距離が選択されていません")
                }
            }
        } else {
            val handler = Handler()
            val run = Runnable {
                kotlin.run {
                    progressDialog?.dismiss()
                }
            }
            progressDialog?.apply {
                setTitle(getString(R.string.loading_return))
                setProgressStyle(ProgressDialog.STYLE_SPINNER)
                show()
            }
            handler.postDelayed(run, 1000)
        }
    }
```

strings.xml 23行目
`<string name="loading_return">位置情報取得中です...\n再度お試しください。</string>`

・確認内容
表記、動作に問題がないこと